### PR TITLE
Add dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - opencensus >=0.7.13,<1.0.0
     - psutil >=5.6.3
     - requests >=2.19.0
+    - azure-core >=1.12.0,<2.0.0
+    - azure-identity>=1.5.0,<2.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - psutil >=5.6.3
     - requests >=2.19.0
     - azure-core >=1.12.0,<2.0.0
-    - azure-identity>=1.5.0,<2.0.0
+    - azure-identity >=1.5.0,<2.0.0
 
 test:
   imports:


### PR DESCRIPTION
The pip package depends on azure core and azure identity. Without these package use of this fails with an import error
see for example the qcodes build here  https://github.com/QCoDeS/Qcodes/pull/3426/checks?check_run_id=3801469033
This fails with 

```
qcodes/logger/logger.py:25: in <module>
    from opencensus.ext.azure.log_exporter import AzureLogHandler
/usr/share/miniconda/envs/qcodesforge/lib/python3.7/site-packages/opencensus/ext/azure/log_exporter/__init__.py:33: in <module>
    from opencensus.ext.azure.common.transport import TransportMixin
/usr/share/miniconda/envs/qcodesforge/lib/python3.7/site-packages/opencensus/ext/azure/common/transport.py:22: in <module>
    from azure.core.exceptions import ClientAuthenticationError
E   ModuleNotFoundError: No module named 'azure'
```